### PR TITLE
trigger analytics event when new regions are requested

### DIFF
--- a/src/client/startup.js
+++ b/src/client/startup.js
@@ -147,6 +147,11 @@ sand.globalFunctions = {
 					}
 				}
 			});
+			try {
+				ga('send', 'event', 'regions', 'addMore', newRegionNames, newRegionNames.length);				
+			} catch (err) {
+				//  Occasionally this function will throw an error when the client has blocked google analytics
+			}
 		}
 	},
 


### PR DESCRIPTION
This might need to be updated. I'm trying a new way to store event data, but I need 24 hrs so I can look at the analytics data to see how it looks on the other end. 

At the moment this should provide accurate "time on site", and a rough idea of how much people are exploring. 

It also seems like the program might make multiple identical ajax requests? So that might add a bit of noise. 

:ok_hand: :hamster: 
